### PR TITLE
Move SupportButton to left

### DIFF
--- a/src/components/buttons/SupportButton.js
+++ b/src/components/buttons/SupportButton.js
@@ -32,7 +32,7 @@ const ButtonLink = styled.a.attrs(() => ({
   line-height: 17px;
   padding: 0 10px;
   position: fixed;
-  right: 30px;
+  left: 30px;
   text-align: center;
   text-decoration: none;
 


### PR DESCRIPTION
This is to prevent the button from obscuring the submit buttons. A temporary measure for the demo on 07/24/2019. Should eventually move this instead to the nav header.

![image](https://user-images.githubusercontent.com/27182199/61775475-dc640280-adad-11e9-97f5-1da39f031ee7.png)
