### PR TITLE
Update multiple search fields with exact

### DIFF
--- a/src/containers/pages/subjectinformation/SubjectQuickSearch.js
+++ b/src/containers/pages/subjectinformation/SubjectQuickSearch.js
@@ -97,7 +97,7 @@ class SubjectQuickSearch extends Component<Props, State> {
       if (value && value.length) {
         actions.searchConsumers({
           entitySetId: getPeopleESId(app),
-          query: value
+          query: `${value}*`
         });
       }
     }, 500);

--- a/src/containers/people/PeopleSagas.js
+++ b/src/containers/people/PeopleSagas.js
@@ -117,12 +117,11 @@ function* searchPeopleWorker(action :SequenceAction) :Generator<*, *, *> {
     const dobPTID :UUID = edm.getIn(['fqnToIdMap', FQN.PERSON_DOB_FQN]);
 
     const searchFields = [];
-    const updateSearchField = (searchString :string, property :string, exact? :boolean) => {
-      const searchTerm = exact ? `"${searchString}"` : searchString;
+    const updateSearchField = (searchTerm :string, property :string) => {
       searchFields.push({
         searchTerm,
         property,
-        exact
+        exact: true
       });
     };
 
@@ -139,14 +138,14 @@ function* searchPeopleWorker(action :SequenceAction) :Generator<*, *, *> {
     if (dob.length) {
       const dobDT = DateTime.fromISO(dob);
       if (dobDT.isValid) {
-        updateSearchField(dobDT.toISODate(), dobPTID, true);
+        updateSearchField(dobDT.toISODate(), dobPTID);
       }
     }
 
     const searchOptions = {
       searchFields,
       start: 0,
-      maxHits: 100
+      maxHits: 10000
     };
 
     const entitySetId = getPeopleESId(app);

--- a/src/containers/search/SearchSagas.js
+++ b/src/containers/search/SearchSagas.js
@@ -42,7 +42,7 @@ function* searchConsumersWorker(action :SequenceAction) :Generator<*, *, *> {
         searchOptions: {
           searchTerm: action.value.query,
           start: 0,
-          maxHits: 100
+          maxHits: 10000
         },
       })
     );


### PR DESCRIPTION
Prior to this change, searching for people with multiple fields was not `exact`. If you input "John" and "Doe" it would bring back results for people who had last name Doe OR who had first name John. 

This update changes the behavior to use "exact" such that the search results will only bring back people whose properties matched all searched properties.