### PR TITLE
Release 2020-04-09

### DIFF
--- a/src/containers/reports/symptoms/SymptomsReportSagas.js
+++ b/src/containers/reports/symptoms/SymptomsReportSagas.js
@@ -90,7 +90,10 @@ function* getAllSymptomsReportsWorker(action :SequenceAction) :Generator<any, an
       const { days = 0 } = contactDateTime.until(now).toDuration(['days'])
         .toObject();
 
-      return days < 14;
+      const symptomValues = symptom.getIn(['neighborDetails', FQN.NAME_FQN]);
+      const noSymptoms = symptomValues.includes('None') && symptomValues.count() === 1;
+
+      return (days < 14) && !noSymptoms;
     }).count() > 0;
 
     yield put(getAllSymptomsReports.success(action.id, {

--- a/src/containers/reports/symptoms/schemas/index.js
+++ b/src/containers/reports/symptoms/schemas/index.js
@@ -52,6 +52,7 @@ const uiSchema = {
       'ui:options': {
         mode: 'button',
         row: true,
+        withNone: true,
       },
     },
     [getEntityAddressKey(0, SYMPTOM_FQN, FQN.DESCRIPTION_FQN)]: {


### PR DESCRIPTION
# Changes
- Add "None" option to Symptoms Report
- Symptoms Reports that have "None" selected do not trigger the COVID-19 banner on profiles. The COVID-19 banner still only considers reports within the last 14 days.