### PR TITLE
fix link button for regular crisis report (no incident)

### DIFF
--- a/src/containers/people/ReportSelectionBody.js
+++ b/src/containers/people/ReportSelectionBody.js
@@ -65,11 +65,11 @@ const ReportSelectionBody = (props :Props) => {
             </>
           )
           : (
-            <Button
+            <LinkButton
                 to={crisisPath}
-                state={selectedPerson}>
+                state={{ selectedPerson }}>
               Crisis Report
-            </Button>
+            </LinkButton>
           )
       }
       <LinkButton


### PR DESCRIPTION
Fix Crisis Report button not working for v1 reports.