### PR TITLE
Feature/apps 3129 xml error reporting

### DIFF
--- a/src/containers/reports/crisis/CrisisReportSagas.js
+++ b/src/containers/reports/crisis/CrisisReportSagas.js
@@ -637,6 +637,7 @@ function* getCrisisReportV2DataWorker(
 
   }
   catch (error) {
+    error.metadata = action;
     response = {
       error
     };

--- a/src/containers/reports/export/ExportBulkReducer.js
+++ b/src/containers/reports/export/ExportBulkReducer.js
@@ -26,8 +26,7 @@ export default function reducer(state :Map = INITIAL_STATE, action :Object) {
           .set('fetchState', RequestStates.PENDING),
         SUCCESS: () => {
           const { errors, filename, skipped } = action.value;
-          const SKIPPED_COUNT = `Failed to load ${skipped.length} reports.`;
-          const allErrors = skipped.length ? errors.push(SKIPPED_COUNT) : errors;
+          const allErrors = skipped.length ? errors.concat(skipped) : errors;
           return state
             .set('errors', allErrors)
             .set('filename', filename)

--- a/src/containers/reports/export/ExportErrorAccordion.js
+++ b/src/containers/reports/export/ExportErrorAccordion.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import type { Node } from 'react';
+
+import { Link } from 'react-router-dom';
+import type { UUID } from 'lattice';
+
+import Accordion from '../../../components/accordion';
+
+type Props = {
+  caption ?:Node;
+  errors :string[];
+  headline :Node;
+  path :string;
+  reportEKID :UUID;
+};
+
+const ExportErrorAccordion = ({
+  caption,
+  errors,
+  headline,
+  path,
+  reportEKID,
+} :Props) => {
+  const subtitle = caption || <Link target="_blank" to={path}>{reportEKID}</Link>;
+  return (
+    <Accordion>
+      <div caption={subtitle} headline={headline}>
+        <ul>
+          { errors.map((msg, idx) => (<li key={idx}>{msg}</li>))}
+        </ul>
+      </div>
+    </Accordion>
+  );
+};
+
+ExportErrorAccordion.defaultProps = {
+  caption: '',
+};
+
+export default ExportErrorAccordion;

--- a/src/containers/reports/export/ExportErrorAccordion.js
+++ b/src/containers/reports/export/ExportErrorAccordion.js
@@ -7,12 +7,13 @@ import { Link } from 'react-router-dom';
 import type { UUID } from 'lattice';
 
 import Accordion from '../../../components/accordion';
+import { CRISIS_REPORT_CLINICIAN_PATH, REPORT_ID_PATH } from '../../../core/router/Routes';
 
 type Props = {
   caption ?:Node;
   errors :string[];
   headline :Node;
-  path :string;
+  path ?:string;
   reportEKID :UUID;
 };
 
@@ -23,10 +24,11 @@ const ExportErrorAccordion = ({
   path,
   reportEKID,
 } :Props) => {
-  const subtitle = caption || <Link target="_blank" to={path}>{reportEKID}</Link>;
+  const defaultPath = CRISIS_REPORT_CLINICIAN_PATH.replace(REPORT_ID_PATH, reportEKID);
+  const defaultCaption = <Link target="_blank" to={path || defaultPath}>{reportEKID}</Link>;
   return (
     <Accordion>
-      <div caption={subtitle} headline={headline}>
+      <div caption={caption || defaultCaption} headline={headline}>
         <ul>
           { errors.map((msg, idx) => (<li key={idx}>{msg}</li>))}
         </ul>
@@ -37,6 +39,7 @@ const ExportErrorAccordion = ({
 
 ExportErrorAccordion.defaultProps = {
   caption: '',
+  path: ''
 };
 
 export default ExportErrorAccordion;

--- a/src/containers/reports/export/ExportSagas.js
+++ b/src/containers/reports/export/ExportSagas.js
@@ -20,6 +20,7 @@ import type { Saga } from '@redux-saga/core';
 import type { WorkerResponse } from 'lattice-sagas';
 import type { SequenceAction } from 'redux-reqseq';
 
+import getExportErrorAccordion from './ExportErrorAccordion';
 import {
   EXPORT_CRISIS_CSV_BY_DATE_RANGE,
   EXPORT_CRISIS_XML,
@@ -290,7 +291,12 @@ function* exportCrisisXMLByDateRangeWorker(action :SequenceAction) :Saga<void> {
         filteredClinicianReportResponses.push(clinicianResponse);
       }
       else if (clinicianResponse.error) {
-        skipped.push(clinicianResponse.error);
+        const { reportEKID } = clinicianResponse.error.metadata;
+        skipped.push(getExportErrorAccordion({
+          headline: 'Failed',
+          errors: [clinicianResponse.error.message],
+          reportEKID
+        }));
       }
     });
 

--- a/src/containers/reports/export/ExportUtils.js
+++ b/src/containers/reports/export/ExportUtils.js
@@ -260,6 +260,7 @@ type XMLPayload = {|
   errors :string[];
   jdpRecord :JDPRecord;
   reportData :ReportData;
+  warnings :string[];
 |};
 
 /* eslint-disable no-param-reassign */
@@ -360,7 +361,7 @@ const insertLocation = (xmlPayload :XMLPayload) => {
     xmlPayload.jdpRecord.LocationOpt = value;
   }
   else {
-    xmlPayload.errors.push(`Invalid "Location Category" - Defaulting to "${OTHER}"`);
+    xmlPayload.warnings.push(`Invalid "Location Category" - Defaulting to "${OTHER}"`);
   }
 
   return xmlPayload;
@@ -456,7 +457,7 @@ const insertMilitaryService = (xmlPayload :XMLPayload) => {
   }
   else {
     xmlPayload.jdpRecord.MilSrvOpt = UNKNOWN;
-    xmlPayload.errors.push(`Invalid history of military service. Defaulting to "${UNKNOWN}"`);
+    xmlPayload.warnings.push(`Invalid history of military service. Defaulting to "${UNKNOWN}"`);
   }
   return xmlPayload;
 };
@@ -477,7 +478,7 @@ const insertSubstance = (xmlPayload :XMLPayload) => {
   }
   else {
     xmlPayload.jdpRecord.SAcurrtOpt = UNKNOWN;
-    xmlPayload.errors.push(`Invalid "Substance use during incident" - Defaulting to "${UNKNOWN}"`);
+    xmlPayload.warnings.push(`Invalid "Substance use during incident" - Defaulting to "${UNKNOWN}"`);
   }
 
   return xmlPayload;
@@ -509,7 +510,7 @@ const insertAdditionalSupport = (xmlPayload :XMLPayload) => {
   }
   else {
     xmlPayload.jdpRecord.AddlSptOSOpt = NONE;
-    xmlPayload.errors.push(`Invalid "Assistance on scene" - Defaulting to ${NONE}`);
+    xmlPayload.warnings.push(`Invalid "Assistance on scene" - Defaulting to ${NONE}`);
   }
 
   return xmlPayload;
@@ -523,7 +524,7 @@ const insertJailDiversion = (xmlPayload :XMLPayload) => {
   const jailDiversion = encounterDetails.getIn([FQN.LAW_ENFORCEMENT_INVOLVEMENT_FQN, 0]);
   xmlPayload.jdpRecord.JDOpt = jailDiversion ? 'Yes' : 'No';
   if (jailDiversion === undefined) {
-    xmlPayload.errors.push(`Invalid "Was jail diversion an option?" - Defaulting to ${NO}`);
+    xmlPayload.warnings.push(`Invalid "Was jail diversion an option?" - Defaulting to ${NO}`);
   }
 
   return xmlPayload;
@@ -656,7 +657,7 @@ const insertInsurance = (xmlPayload :XMLPayload) => {
   const [primary, primaryHit] = transformValue(primaryRaw, transformMap, UNKNOWN);
 
   xmlPayload.jdpRecord.PrimSrcOpt = primary;
-  if (!primaryHit) xmlPayload.errors.push(`Invalid "Primary Insurance" - Defaulting to "${UNKNOWN}"`);
+  if (!primaryHit) xmlPayload.warnings.push(`Invalid "Primary Insurance" - Defaulting to "${UNKNOWN}"`);
 
   const secondaryEntity = insurances
     .find((neighbor) => neighbor.getIn([FQN.GENERAL_STATUS_FQN, 0]) === SECONDARY) || Map();
@@ -666,7 +667,7 @@ const insertInsurance = (xmlPayload :XMLPayload) => {
   const [secondary, secondaryHit] = transformValue(secondaryRaw, transformMap, UNKNOWN);
 
   xmlPayload.jdpRecord.SecSrcOpt = secondary;
-  if (!secondaryHit) xmlPayload.errors.push(`Invalid "Secondary Insurance" - Defaulting to "${UNKNOWN}"`);
+  if (!secondaryHit) xmlPayload.warnings.push(`Invalid "Secondary Insurance" - Defaulting to "${UNKNOWN}"`);
 
   return xmlPayload;
 };
@@ -739,7 +740,7 @@ const insertStateService = (xmlPayload :XMLPayload) => {
   const [serviceName, hit] = transformValue(value, transformMap, UNKNOWN);
 
   xmlPayload.jdpRecord.KnownOpt = serviceName;
-  if (!hit) xmlPayload.errors.push(`Invalid "Client of State Service" - Defaulting to ${UNKNOWN}`);
+  if (!hit) xmlPayload.warnings.push(`Invalid "Client of State Service" - Defaulting to ${UNKNOWN}`);
 
   return xmlPayload;
 };
@@ -757,7 +758,7 @@ const insertRaceEthnicity = (xmlPayload :XMLPayload) => {
 
   const [ethnicity, ethnicityHit] = transformValue(ethnicityRaw, ethnicityMap, UNKNOWN);
   xmlPayload.jdpRecord.HPOpt = ethnicity;
-  if (!ethnicityHit) xmlPayload.errors.push(`Invalid "Ethnicity" - Defaulting to ${UNKNOWN}`);
+  if (!ethnicityHit) xmlPayload.warnings.push(`Invalid "Ethnicity" - Defaulting to ${UNKNOWN}`);
 
   const raceMap = Map({
     [WHITE]: WHITE,
@@ -770,7 +771,7 @@ const insertRaceEthnicity = (xmlPayload :XMLPayload) => {
   const [race, raceHit] = transformValue(raceRaw, raceMap, UNKNOWN);
 
   xmlPayload.jdpRecord.RaceOpt = race;
-  if (!raceHit) xmlPayload.errors.push(`Invalid "Race" - Defaulting to ${UNKNOWN}`);
+  if (!raceHit) xmlPayload.warnings.push(`Invalid "Race" - Defaulting to ${UNKNOWN}`);
 
   return xmlPayload;
 };
@@ -793,7 +794,7 @@ const insertEmployment = (xmlPayload :XMLPayload) => {
   const [employment, hit] = transformValue(employmentValue, transformMap, UNKNOWN);
   xmlPayload.jdpRecord.EmpSrcOpt = employment;
 
-  if (!hit) xmlPayload.errors.push(`Invalid "Occupation" - Defaulting to ${UNKNOWN}`);
+  if (!hit) xmlPayload.warnings.push(`Invalid "Occupation" - Defaulting to ${UNKNOWN}`);
 
   return xmlPayload;
 };
@@ -821,7 +822,7 @@ const insertResidence = (xmlPayload :XMLPayload) => {
   const [type, typeHit] = transformValue(typeValue, typeMap, UNKNOWN);
 
   xmlPayload.jdpRecord.LivOpt = type;
-  if (!typeHit) xmlPayload.errors.push(`Invalid "Current Housing Situation" - Defaulting to ${UNKNOWN}`);
+  if (!typeHit) xmlPayload.warnings.push(`Invalid "Current Housing Situation" - Defaulting to ${UNKNOWN}`);
 
   const livesWithOptions :List = housingEntity.get(FQN.DESCRIPTION_FQN, List());
   const [livesWithRaw, other] = otherValueFromList(livesWithOptions);
@@ -843,7 +844,7 @@ const insertResidence = (xmlPayload :XMLPayload) => {
   const [livesWith, livesWithHit] = transformValue(livesWithRaw, livesWithMap, UNKNOWN);
   xmlPayload.jdpRecord.WithOpt = livesWith;
   xmlPayload.jdpRecord.WithOth = other;
-  if (!livesWithHit) xmlPayload.errors.push(`Invalid "Resides With" - Defaulting to ${UNKNOWN}`);
+  if (!livesWithHit) xmlPayload.warnings.push(`Invalid "Resides With" - Defaulting to ${UNKNOWN}`);
 
   return xmlPayload;
 };
@@ -863,7 +864,7 @@ const insertPriorArrests = (xmlPayload :XMLPayload) => {
 
   const [priorArrests, hits] = transformValue(priorArrestRaw, transformMap, UNKNOWN);
   xmlPayload.jdpRecord.PriorOpt = priorArrests;
-  if (!hits) xmlPayload.errors.push(`Invalid "Prior Arrests" - Defaulting to ${UNKNOWN}`);
+  if (!hits) xmlPayload.warnings.push(`Invalid "Prior Arrests" - Defaulting to ${UNKNOWN}`);
 
   return xmlPayload;
 };
@@ -884,7 +885,7 @@ const insertSubstanceHistory = (xmlPayload :XMLPayload) => {
   }
   else {
     xmlPayload.jdpRecord.SubOpt = UNKNOWN;
-    xmlPayload.errors.push(`Invalid "History of substance abuse/treatment" - Defaulting to "${UNKNOWN}"`);
+    xmlPayload.warnings.push(`Invalid "History of substance abuse/treatment" - Defaulting to "${UNKNOWN}"`);
   }
 
   return xmlPayload;
@@ -908,7 +909,7 @@ const insertPresenceOfPsychiatricIssue = (xmlPayload :XMLPayload) => {
   });
   const [presenting, hit] = transformValue(psychIssue, transformMap, UNKNOWN);
   xmlPayload.jdpRecord.PresOpt = presenting;
-  if (!hit) xmlPayload.errors.push(`Invalid "Presenting Psychiatric Issue" - Defaulting to ${UNKNOWN}`);
+  if (!hit) xmlPayload.warnings.push(`Invalid "Presenting Psychiatric Issue" - Defaulting to ${UNKNOWN}`);
 
   return xmlPayload;
 };
@@ -924,7 +925,13 @@ const insertTimestamp = (xmlPayload :XMLPayload) => {
 };
 
 const createJDPRecord = (reportData :ReportData) :XMLPayload => {
-  const initialPayload :XMLPayload = { reportData, jdpRecord: {}, errors: [] };
+  const initialPayload :XMLPayload = {
+    errors: [],
+    jdpRecord: {},
+    reportData,
+    warnings: [],
+  };
+
   return pipe(
     insertEntryDate,
     insertJDP,
@@ -958,7 +965,7 @@ const createJDPRecord = (reportData :ReportData) :XMLPayload => {
 };
 
 const generateXMLFromReportData = (reportData :ReportData) :Object => {
-  const { jdpRecord, errors } = createJDPRecord(reportData);
+  const { errors, jdpRecord, warnings } = createJDPRecord(reportData);
   const { clinicianReportData } = reportData;
   const incidentID = clinicianReportData
     .getIn([INCIDENT_FQN, 0, NEIGHBOR_DETAILS, FQN.CRIMINALJUSTICE_CASE_NUMBER_FQN, 0]);
@@ -980,6 +987,7 @@ const generateXMLFromReportData = (reportData :ReportData) :Object => {
 
   return ({
     errors: List(errors),
+    warnings: List(warnings),
     filename
   });
 };

--- a/src/containers/reports/export/ExportUtils.js
+++ b/src/containers/reports/export/ExportUtils.js
@@ -1007,13 +1007,11 @@ const generateXMLFromReportRange = (reportData :ReportData[], dateStart :string,
     const { clinicianReportData } = payload.reportData;
     const reportEKID = clinicianReportData
       .getIn([CRISIS_REPORT_CLINICIAN_FQN, 0, NEIGHBOR_DETAILS, FQN.OPENLATTICE_ID_FQN, 0]);
-    const path = CRISIS_REPORT_CLINICIAN_PATH.replace(REPORT_ID_PATH, reportEKID);
     if (payload.errors.length) {
       const element = (
         <ExportErrorAccordion
             errors={payload.errors}
             headline="Excluded"
-            path={path}
             reportEKID={reportEKID} />
       );
       errors.push(element);
@@ -1024,7 +1022,6 @@ const generateXMLFromReportRange = (reportData :ReportData[], dateStart :string,
           <ExportErrorAccordion
               errors={payload.warnings}
               headline="Warning"
-              path={path}
               reportEKID={reportEKID} />
         );
         errors.push(element);

--- a/src/containers/reports/export/ExportUtils.js
+++ b/src/containers/reports/export/ExportUtils.js
@@ -11,14 +11,11 @@ import {
 } from 'immutable';
 import { DateTimeUtils, LangUtils } from 'lattice-utils';
 import { DateTime } from 'luxon';
-import { Link } from 'react-router-dom';
 
 import ExportErrorAccordion from './ExportErrorAccordion';
 
-import Accordion from '../../../components/accordion';
 import FileSaver from '../../../utils/FileSaver';
 import * as FQN from '../../../edm/DataModelFqns';
-import { CRISIS_REPORT_CLINICIAN_PATH, REPORT_ID_PATH } from '../../../core/router/Routes';
 import { APP_TYPES_FQNS } from '../../../shared/Consts';
 import { NEIGHBOR_DETAILS } from '../../../utils/constants/EntityConstants';
 import { TEXT_XML, XML_HEADER } from '../../../utils/constants/FileTypeConstants';


### PR DESCRIPTION
- Enhance error messaging for bulk XML exports. Each message contains clickable anchor tag that directs to the report.
  - Non-critical errors are no longer excluded and categorized as "Warning"
  - Critical errors with known incompatibilities with DMH reporting are excluded and categorized as "Excluded"
  - Reports that fail to load are categorized as "Failed"
![image](https://user-images.githubusercontent.com/27182199/132799449-948f5028-6863-4302-9c84-18ca314407da.png)
